### PR TITLE
Calculator UX improvements and material filtering

### DIFF
--- a/src/components/item-picker.tsx
+++ b/src/components/item-picker.tsx
@@ -28,6 +28,7 @@ interface ItemPickerProps {
   onSelect: (name: string | null) => void
   placeholder?: string
   label?: string
+  formatType?: (type: string) => string
 }
 
 export function ItemPicker({
@@ -36,8 +37,10 @@ export function ItemPicker({
   onSelect,
   placeholder = "Select item...",
   label,
+  formatType,
 }: ItemPickerProps) {
   const [open, setOpen] = useState(false)
+  const selectedItem = value ? items.find((i) => i.name === value) : null
 
   // Group items by type, sorted by level within each group
   const groups = items.reduce<Record<string, PickerItem[]>>((acc, item) => {
@@ -71,6 +74,13 @@ export function ItemPicker({
                 <span className="min-w-0 flex-1 truncate text-left text-sm font-medium">
                   {value}
                 </span>
+                {selectedItem?.type && (
+                  <span className="text-muted-foreground shrink-0 text-xs">
+                    {formatType
+                      ? formatType(selectedItem.type)
+                      : selectedItem.type}
+                  </span>
+                )}
               </div>
             ) : (
               <span className="text-muted-foreground text-sm">

--- a/src/components/stat-display.tsx
+++ b/src/components/stat-display.tsx
@@ -94,20 +94,128 @@ export function StatDisplay({
       {showAffinities && "human" in stats && (
         <div className="flex flex-col gap-1">
           <div className="flex flex-wrap gap-1.5">
-            <Stat label="Hum" value={stats.human ?? 0} compact />
-            <Stat label="Bst" value={stats.beast ?? 0} compact />
-            <Stat label="Und" value={stats.undead ?? 0} compact />
-            <Stat label="Phm" value={stats.phantom ?? 0} compact />
-            <Stat label="Drg" value={stats.dragon ?? 0} compact />
-            <Stat label="Evl" value={stats.evil ?? 0} compact />
+            <Stat
+              label="Hum"
+              value={stats.human ?? 0}
+              compare={
+                compareWith && "human" in compareWith
+                  ? compareWith.human
+                  : undefined
+              }
+              compact
+            />
+            <Stat
+              label="Bst"
+              value={stats.beast ?? 0}
+              compare={
+                compareWith && "beast" in compareWith
+                  ? compareWith.beast
+                  : undefined
+              }
+              compact
+            />
+            <Stat
+              label="Und"
+              value={stats.undead ?? 0}
+              compare={
+                compareWith && "undead" in compareWith
+                  ? compareWith.undead
+                  : undefined
+              }
+              compact
+            />
+            <Stat
+              label="Phm"
+              value={stats.phantom ?? 0}
+              compare={
+                compareWith && "phantom" in compareWith
+                  ? compareWith.phantom
+                  : undefined
+              }
+              compact
+            />
+            <Stat
+              label="Drg"
+              value={stats.dragon ?? 0}
+              compare={
+                compareWith && "dragon" in compareWith
+                  ? compareWith.dragon
+                  : undefined
+              }
+              compact
+            />
+            <Stat
+              label="Evl"
+              value={stats.evil ?? 0}
+              compare={
+                compareWith && "evil" in compareWith
+                  ? compareWith.evil
+                  : undefined
+              }
+              compact
+            />
           </div>
           <div className="flex flex-wrap gap-1.5">
-            <Stat label="Fir" value={stats.fire ?? 0} compact />
-            <Stat label="Wat" value={stats.water ?? 0} compact />
-            <Stat label="Wnd" value={stats.wind ?? 0} compact />
-            <Stat label="Ear" value={stats.earth ?? 0} compact />
-            <Stat label="Lit" value={stats.light ?? 0} compact />
-            <Stat label="Drk" value={stats.dark ?? 0} compact />
+            <Stat
+              label="Fir"
+              value={stats.fire ?? 0}
+              compare={
+                compareWith && "fire" in compareWith
+                  ? compareWith.fire
+                  : undefined
+              }
+              compact
+            />
+            <Stat
+              label="Wat"
+              value={stats.water ?? 0}
+              compare={
+                compareWith && "water" in compareWith
+                  ? compareWith.water
+                  : undefined
+              }
+              compact
+            />
+            <Stat
+              label="Wnd"
+              value={stats.wind ?? 0}
+              compare={
+                compareWith && "wind" in compareWith
+                  ? compareWith.wind
+                  : undefined
+              }
+              compact
+            />
+            <Stat
+              label="Ear"
+              value={stats.earth ?? 0}
+              compare={
+                compareWith && "earth" in compareWith
+                  ? compareWith.earth
+                  : undefined
+              }
+              compact
+            />
+            <Stat
+              label="Lit"
+              value={stats.light ?? 0}
+              compare={
+                compareWith && "light" in compareWith
+                  ? compareWith.light
+                  : undefined
+              }
+              compact
+            />
+            <Stat
+              label="Drk"
+              value={stats.dark ?? 0}
+              compare={
+                compareWith && "dark" in compareWith
+                  ? compareWith.dark
+                  : undefined
+              }
+              compact
+            />
           </div>
         </div>
       )}
@@ -127,14 +235,14 @@ function Stat({
   compact?: boolean
 }) {
   const diff = compare != null ? compare - value : undefined
-  const size = compact ? "min-w-9 px-1.5 py-1" : "min-w-11 px-2 py-1.5"
+  const size = compact ? "min-w-10 px-1.5 py-1" : "min-w-11 px-2 py-1.5"
 
   return (
     <div className={cn("bg-muted/50 flex flex-col items-center rounded", size)}>
       <span
         className={cn(
           "text-muted-foreground leading-none",
-          compact ? "text-[10px]" : "text-xs"
+          compact ? "text-[11px]" : "text-xs"
         )}
       >
         {label}
@@ -142,7 +250,7 @@ function Stat({
       <span
         className={cn(
           "leading-tight font-medium",
-          compact ? "text-xs" : "text-sm",
+          "text-sm",
           value > 0 && "text-green-400",
           value < 0 && "text-red-400",
           value === 0 && "text-muted-foreground"
@@ -154,7 +262,7 @@ function Stat({
         <span
           className={cn(
             "leading-none font-medium",
-            compact ? "text-[10px]" : "text-xs",
+            "text-xs",
             diff > 0 ? "text-green-400" : "text-red-400"
           )}
         >

--- a/src/pages/calculator/calculator-page.tsx
+++ b/src/pages/calculator/calculator-page.tsx
@@ -16,6 +16,7 @@ import {
   ArrowUpDown,
   Plus,
   RotateCcw,
+  X,
 } from "lucide-react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
@@ -38,7 +39,15 @@ import {
 import { computeEffectiveStats, type ItemStats } from "@/lib/item-stats"
 import { cn } from "@/lib/utils"
 
-const MATERIALS = [
+const TYPE_LABELS: Record<string, string> = {
+  AxeMace: "Axe / Mace",
+}
+
+function typeLabel(type: string) {
+  return TYPE_LABELS[type] ?? type
+}
+
+const ALL_MATERIALS = [
   "Wood",
   "Leather",
   "Bronze",
@@ -47,6 +56,10 @@ const MATERIALS = [
   "Silver",
   "Damascus",
 ]
+
+const BLADE_MATS = ["Bronze", "Iron", "Hagane", "Silver", "Damascus"]
+const ARMOR_MATS = ["Leather", "Bronze", "Iron", "Hagane", "Silver", "Damascus"]
+const SHIELD_MATS = ["Wood", "Bronze", "Iron", "Hagane", "Silver", "Damascus"]
 
 // The API blade_type values don't match the material recipe type categories.
 // This maps API blade_type → material recipe input type.
@@ -201,6 +214,34 @@ export function CalculatorPage() {
     return map
   }, [allItems, recipes])
 
+  // Map item name → equipment category for material filtering
+  const equipCategoryMap = useMemo(() => {
+    const map = new Map<string, "blade" | "armor" | "shield">()
+    for (const w of weapons) map.set(fmt(w.field_name), "blade")
+    for (const a of armor) {
+      if (a.armor_type === "Shield") map.set(fmt(a.field_name), "shield")
+      else map.set(fmt(a.field_name), "armor")
+    }
+    // Handle recipe items not in weapons/armor (e.g. shields from crafting)
+    for (const r of recipes) {
+      for (const name of [r.input_1, r.input_2, r.result]) {
+        if (map.has(name)) continue
+        if (r.category === "shield") map.set(name, "shield")
+      }
+    }
+    return map
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [weapons, armor, recipes])
+
+  function getMaterialsForItem(itemName: string | null): string[] {
+    if (!itemName) return ALL_MATERIALS
+    const cat = equipCategoryMap.get(itemName)
+    if (cat === "blade") return BLADE_MATS
+    if (cat === "shield") return SHIELD_MATS
+    if (cat === "armor") return ARMOR_MATS
+    return ALL_MATERIALS
+  }
+
   const CATEGORY_OPTIONS = [
     { value: "all", label: "All Equipment" },
     { value: "weapons", label: "Weapons" },
@@ -273,6 +314,16 @@ export function CalculatorPage() {
 
       return { ...match, orderMatters }
     }, [materialA, materialB, itemA, itemB, itemTypeMap, materialRecipes])
+
+  const resultCompareStats = useMemo(() => {
+    if (results.length === 0) return undefined
+    const base = itemStatsMap.get(results[0].result)
+    if (!base) return undefined
+    if (!materialResult) return base
+    const mat = materialMap.get(materialResult.result_material)
+    if (!mat) return base
+    return computeEffectiveStats(base, mat)
+  }, [results, itemStatsMap, materialResult, materialMap])
 
   // --- Reverse lookup ---
   const resultItems: PickerItem[] = useMemo(() => {
@@ -401,13 +452,23 @@ export function CalculatorPage() {
         </div>
         <div className="flex w-full flex-col items-center gap-6 sm:flex-row sm:items-stretch">
           <ItemCard
-            title="Item 1"
+            title="Slot 1"
             items={filteredItems}
             value={itemA}
-            onSelect={setItemA}
+            onSelect={(name) => {
+              setItemA(name)
+              if (
+                materialA &&
+                name &&
+                !getMaterialsForItem(name).includes(materialA)
+              )
+                setMaterialA(null)
+            }}
             material={materialA}
             onMaterialSelect={setMaterialA}
+            availableMaterials={getMaterialsForItem(itemA)}
             stats={itemA ? itemStatsMap.get(itemA) : undefined}
+            compareWith={resultCompareStats}
             materialData={materialA ? materialMap.get(materialA) : undefined}
           />
 
@@ -416,13 +477,23 @@ export function CalculatorPage() {
           </div>
 
           <ItemCard
-            title="Item 2"
+            title="Slot 2"
             items={filteredItems}
             value={itemB}
-            onSelect={setItemB}
+            onSelect={(name) => {
+              setItemB(name)
+              if (
+                materialB &&
+                name &&
+                !getMaterialsForItem(name).includes(materialB)
+              )
+                setMaterialB(null)
+            }}
             material={materialB}
             onMaterialSelect={setMaterialB}
+            availableMaterials={getMaterialsForItem(itemB)}
             stats={itemB ? itemStatsMap.get(itemB) : undefined}
+            compareWith={resultCompareStats}
             materialData={materialB ? materialMap.get(materialB) : undefined}
           />
 
@@ -446,12 +517,23 @@ export function CalculatorPage() {
                       ? computeEffectiveStats(resultStats, resultMat)
                       : resultStats
 
+                  const resultType = allItems.find(
+                    (i) => i.name === r.result
+                  )?.type
+
                   return (
                     <div key={r.id} className="space-y-3">
                       {/* Item name — mimics ItemPicker trigger */}
                       <div className="flex min-h-12 items-center gap-2 rounded-md border px-3 py-2">
                         <div className="bg-muted size-8 shrink-0 rounded" />
-                        <span className="text-sm font-medium">{r.result}</span>
+                        <span className="min-w-0 flex-1 truncate text-sm font-medium">
+                          {r.result}
+                        </span>
+                        {resultType && (
+                          <span className="text-muted-foreground shrink-0 text-xs">
+                            {typeLabel(resultType)}
+                          </span>
+                        )}
                       </div>
                       {/* Material — mimics MaterialSelect */}
                       <div className="flex h-10 items-center gap-1.5 rounded-md border px-3">
@@ -535,13 +617,22 @@ export function CalculatorPage() {
             <ItemPicker
               items={reverseFilteredItems}
               value={targetItem}
-              onSelect={setTargetItem}
+              onSelect={(name) => {
+                setTargetItem(name)
+                if (
+                  targetMaterial &&
+                  name &&
+                  !getMaterialsForItem(name).includes(targetMaterial)
+                )
+                  setTargetMaterial(null)
+              }}
               placeholder="Search for a result item..."
+              formatType={typeLabel}
             />
           </div>
           <div className="sm:w-48">
             <MaterialSelect
-              materials={MATERIALS}
+              materials={getMaterialsForItem(targetItem)}
               value={targetMaterial}
               onSelect={setTargetMaterial}
             />
@@ -589,7 +680,9 @@ function ItemCard({
   onSelect,
   material,
   onMaterialSelect,
+  availableMaterials,
   stats,
+  compareWith,
   materialData,
 }: {
   title: string
@@ -598,12 +691,13 @@ function ItemCard({
   onSelect: (name: string | null) => void
   material: string | null
   onMaterialSelect: (material: string | null) => void
+  availableMaterials: string[]
   stats?: ItemStats
+  compareWith?: ItemStats
   materialData?: Material
 }) {
   const effectiveStats =
     stats && materialData ? computeEffectiveStats(stats, materialData) : stats
-
   return (
     <Card className="w-full flex-1">
       <CardHeader className="pb-3">
@@ -615,14 +709,19 @@ function ItemCard({
           value={value}
           onSelect={onSelect}
           placeholder={`Choose ${title.toLowerCase()}...`}
+          formatType={typeLabel}
         />
         <MaterialSelect
-          materials={MATERIALS}
+          materials={availableMaterials}
           value={material}
           onSelect={onMaterialSelect}
         />
         {effectiveStats && (
-          <StatDisplay stats={effectiveStats} showAffinities={!!materialData} />
+          <StatDisplay
+            stats={effectiveStats}
+            compareWith={compareWith}
+            showAffinities={!!materialData}
+          />
         )}
       </CardContent>
     </Card>
@@ -679,7 +778,10 @@ function ReverseTable({
               targetMaterial
                 ? [
                     ...new Set(row.original.materialCombos.map((c) => c.mat1)),
-                  ].sort((a, b) => MATERIALS.indexOf(a) - MATERIALS.indexOf(b))
+                  ].sort(
+                    (a, b) =>
+                      ALL_MATERIALS.indexOf(a) - ALL_MATERIALS.indexOf(b)
+                  )
                 : undefined
             }
           />
@@ -698,7 +800,10 @@ function ReverseTable({
               targetMaterial
                 ? [
                     ...new Set(row.original.materialCombos.map((c) => c.mat2)),
-                  ].sort((a, b) => MATERIALS.indexOf(a) - MATERIALS.indexOf(b))
+                  ].sort(
+                    (a, b) =>
+                      ALL_MATERIALS.indexOf(a) - ALL_MATERIALS.indexOf(b)
+                  )
                 : undefined
             }
           />
@@ -726,35 +831,47 @@ function ReverseTable({
 
   return (
     <Card>
-      <CardHeader className="pb-3">
-        <CardTitle className="text-base">
-          {rows.length} recipe{rows.length !== 1 && "s"} found
+      <div className="bg-card border-border/50 sticky top-14 z-10 space-y-3 border-b px-6 py-4">
+        <p className="text-center text-base font-semibold">
+          {table.getFilteredRowModel().rows.length} recipe
+          {table.getFilteredRowModel().rows.length !== 1 && "s"} found
           {targetMaterial && (
             <span className="text-muted-foreground font-normal">
               {" "}
               · showing material paths for {targetMaterial}
             </span>
           )}
-        </CardTitle>
-      </CardHeader>
-      {targetItem && (
-        <div className="bg-card border-border/50 sticky top-14 z-10 border-b px-6 py-2">
-          <SlotCell
-            name={targetItem}
-            type={itemTypeMap.get(targetItem)}
-            stats={itemStatsMap.get(targetItem)}
-          />
-        </div>
-      )}
-      <CardContent className="space-y-3 overflow-x-auto">
-        {rows.length > 0 && (
-          <Input
-            placeholder="Filter results..."
-            value={globalFilter}
-            onChange={(e) => setGlobalFilter(e.target.value)}
-            className="max-w-sm"
-          />
+        </p>
+        {targetItem && (
+          <div className="flex justify-center">
+            <SlotCell
+              name={targetItem}
+              type={itemTypeMap.get(targetItem)}
+              stats={itemStatsMap.get(targetItem)}
+            />
+          </div>
         )}
+        {rows.length > 0 && (
+          <div className="relative mx-auto max-w-sm">
+            <Input
+              placeholder="Filter results..."
+              value={globalFilter}
+              onChange={(e) => setGlobalFilter(e.target.value)}
+              className="pr-8"
+            />
+            {globalFilter && (
+              <button
+                type="button"
+                onClick={() => setGlobalFilter("")}
+                className="text-muted-foreground hover:text-foreground absolute top-1/2 right-2 -translate-y-1/2"
+              >
+                <X className="size-4" />
+              </button>
+            )}
+          </div>
+        )}
+      </div>
+      <CardContent className="space-y-3 overflow-x-auto">
         {rows.length > 0 ? (
           <table className="w-full text-sm">
             <thead>
@@ -764,10 +881,9 @@ function ReverseTable({
                     <th
                       key={header.id}
                       className={cn(
-                        "text-muted-foreground px-3 py-2 text-left font-medium",
+                        "text-muted-foreground w-1/2 px-3 py-2 text-center font-medium",
                         header.column.getCanSort() &&
-                          "cursor-pointer select-none",
-                        header.id === "tier" && "text-right"
+                          "cursor-pointer select-none"
                       )}
                       onClick={header.column.getToggleSortingHandler()}
                     >
@@ -793,13 +909,15 @@ function ReverseTable({
                 const lowestMat1 =
                   mat1s.length > 0
                     ? mat1s.sort(
-                        (a, b) => MATERIALS.indexOf(a) - MATERIALS.indexOf(b)
+                        (a, b) =>
+                          ALL_MATERIALS.indexOf(a) - ALL_MATERIALS.indexOf(b)
                       )[0]
                     : null
                 const lowestMat2 =
                   mat2s.length > 0
                     ? mat2s.sort(
-                        (a, b) => MATERIALS.indexOf(a) - MATERIALS.indexOf(b)
+                        (a, b) =>
+                          ALL_MATERIALS.indexOf(a) - ALL_MATERIALS.indexOf(b)
                       )[0]
                     : null
 
@@ -813,7 +931,7 @@ function ReverseTable({
                     title="Click to load into calculator"
                   >
                     {row.getVisibleCells().map((cell) => (
-                      <td key={cell.id} className="px-3 py-2">
+                      <td key={cell.id} className="w-1/2 px-3 py-2 text-center">
                         {flexRender(
                           cell.column.columnDef.cell,
                           cell.getContext()
@@ -859,11 +977,15 @@ function SlotCell({
   materials?: string[]
 }) {
   return (
-    <div>
+    <div className="inline-flex flex-col items-center">
       <div className="flex items-center gap-2">
         <div className="bg-muted size-6 shrink-0 rounded" />
         <span className="font-medium">{name}</span>
-        {type && <span className="text-muted-foreground text-xs">{type}</span>}
+        {type && (
+          <span className="text-muted-foreground text-xs">
+            {typeLabel(type)}
+          </span>
+        )}
       </div>
       {stats && (
         <div className="mt-0.5">

--- a/src/pages/materials/materials-page.tsx
+++ b/src/pages/materials/materials-page.tsx
@@ -184,13 +184,13 @@ export function MaterialsPage() {
         {/* Type pair selector */}
         {category !== "Shields" && (
           <Card>
-            <CardContent className="flex items-center gap-3 pt-6">
-              <div className="flex-1">
+            <CardContent className="flex items-end justify-center gap-3 pt-6">
+              <div className="w-48">
                 <span className="text-muted-foreground mb-1 block text-xs font-medium">
                   Slot 1
                 </span>
                 <Select value={type1} onValueChange={setType1}>
-                  <SelectTrigger>
+                  <SelectTrigger className="w-48">
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
@@ -204,17 +204,17 @@ export function MaterialsPage() {
               </div>
               <button
                 onClick={swap}
-                className="text-muted-foreground hover:text-foreground mt-5 shrink-0 px-1 text-lg transition-colors"
+                className="text-muted-foreground hover:text-foreground flex h-9 shrink-0 items-center px-1 text-lg transition-colors"
                 title="Swap slots"
               >
                 ⇄
               </button>
-              <div className="flex-1">
+              <div className="w-48">
                 <span className="text-muted-foreground mb-1 block text-xs font-medium">
                   Slot 2
                 </span>
                 <Select value={type2} onValueChange={setType2}>
-                  <SelectTrigger>
+                  <SelectTrigger className="w-48">
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
@@ -297,7 +297,7 @@ export function MaterialsPage() {
         <p className="text-muted-foreground text-center text-xs">
           Material data based on Jay Tilton's{" "}
           <a
-            href="https://gamefaqs.gamespot.com/ps/914326-vagrant-story/faqs/10457"
+            href="https://gamefaqs.gamespot.com/ps/914326-vagrant-story/faqs/8485"
             className="text-primary hover:underline"
             target="_blank"
             rel="noopener noreferrer"
@@ -356,10 +356,6 @@ function MaterialGrid({
                 <td
                   rowSpan={materials.length}
                   className="text-muted-foreground pr-2 align-middle text-[10px] font-normal"
-                  style={{
-                    writingMode: "vertical-lr",
-                    textOrientation: "mixed",
-                  }}
                 >
                   Slot 1
                 </td>


### PR DESCRIPTION
## Summary
- Filter material selects by equipment category (blades get Bronze–Damascus, armor Leather–Damascus, shields Wood+Bronze–Damascus)
- Stat diffs on forward calculator slots comparing against result (core stats + affinities)
- Item type labels shown inside picker triggers and result card
- Renamed Item 1/2 → Slot 1/2 for consistency across the app
- Sticky reverse lookup header with recipe count, target display, and filter
- Recipe count updates dynamically with search filter
- Centered reverse lookup columns for better readability

**Materials page:**
- Fixed swap button vertical centering
- Slot 1 label now horizontal text
- Fixed combinations guide link (→ faqs/8485)
- Fixed-width selects

## Test plan
- [ ] Select a blade item → material dropdown only shows Bronze through Damascus
- [ ] Select an armor item → material dropdown shows Leather through Damascus
- [ ] Select a shield → material dropdown shows Wood through Damascus
- [ ] Switch from armor to blade with Leather selected → material auto-clears
- [ ] Forward calculator shows stat diffs (green/red) on Slot 1/2 when result exists
- [ ] Affinity diffs appear when materials are selected on both slots
- [ ] Reverse lookup sticky header stays visible when scrolling
- [ ] Filter input updates recipe count in real time
- [ ] Materials page swap button centered, Slot 1 horizontal, guide link correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)