### PR TITLE
URL search params for link sharing, fix error/404 shell

### DIFF
--- a/src/components/error-boundary.tsx
+++ b/src/components/error-boundary.tsx
@@ -10,7 +10,7 @@ export function RootErrorComponent({ error, reset }: ErrorComponentProps) {
   })
 
   return (
-    <div className="flex min-h-svh flex-col items-center justify-center gap-6 p-8">
+    <div className="flex flex-1 flex-col items-center justify-center gap-6 p-8">
       <p className="text-muted-foreground text-sm font-medium tracking-widest uppercase">
         Something went wrong
       </p>

--- a/src/components/not-found.tsx
+++ b/src/components/not-found.tsx
@@ -3,7 +3,7 @@ import { Button } from "@/components/ui/button"
 
 export function NotFound() {
   return (
-    <div className="flex min-h-svh flex-col items-center justify-center gap-6 p-8">
+    <div className="flex flex-1 flex-col items-center justify-center gap-6 p-8">
       <p className="text-muted-foreground text-sm font-medium tracking-widest uppercase">
         Page not found
       </p>

--- a/src/pages/calculator/calculator-page.tsx
+++ b/src/pages/calculator/calculator-page.tsx
@@ -1,4 +1,5 @@
-import { useMemo, useState } from "react"
+import { useCallback, useMemo, useState } from "react"
+import { getRouteApi } from "@tanstack/react-router"
 import { useQuery } from "@tanstack/react-query"
 import {
   flexRender,
@@ -76,16 +77,50 @@ function toMaterialType(apiType: string): string {
   return MATERIAL_TYPE_MAP[apiType] ?? apiType
 }
 
+const routeApi = getRouteApi("/")
+
 export function CalculatorPage() {
-  const [itemA, setItemA] = useState<string | null>(null)
-  const [itemB, setItemB] = useState<string | null>(null)
-  const [materialA, setMaterialA] = useState<string | null>(null)
-  const [materialB, setMaterialB] = useState<string | null>(null)
-  const [targetItem, setTargetItem] = useState<string | null>(null)
-  const [targetMaterial, setTargetMaterial] = useState<string | null>(null)
-  const [categoryFilter, setCategoryFilter] = useState<string>("all")
-  const [reverseCategoryFilter, setReverseCategoryFilter] =
-    useState<string>("all")
+  const search = routeApi.useSearch()
+  const navigate = routeApi.useNavigate()
+
+  const updateSearch = useCallback(
+    (updates: Record<string, string | undefined>) =>
+      navigate({
+        search: (prev: Record<string, string | undefined>) => {
+          const next = { ...prev, ...updates }
+          for (const key of Object.keys(next)) {
+            if (!next[key]) delete next[key]
+          }
+          return next
+        },
+        replace: true,
+      }),
+    [navigate]
+  )
+
+  const itemA = search.s1 ?? null
+  const itemB = search.s2 ?? null
+  const materialA = search.m1 ?? null
+  const materialB = search.m2 ?? null
+  const targetItem = search.target ?? null
+  const targetMaterial = search.tmat ?? null
+  const categoryFilter = search.cat ?? "all"
+  const reverseCategoryFilter = search.rcat ?? "all"
+
+  const setItemA = (v: string | null) => updateSearch({ s1: v || undefined })
+  const setItemB = (v: string | null) => updateSearch({ s2: v || undefined })
+  const setMaterialA = (v: string | null) =>
+    updateSearch({ m1: v || undefined })
+  const setMaterialB = (v: string | null) =>
+    updateSearch({ m2: v || undefined })
+  const setTargetItem = (v: string | null) =>
+    updateSearch({ target: v || undefined })
+  const setTargetMaterial = (v: string | null) =>
+    updateSearch({ tmat: v || undefined })
+  const setCategoryFilter = (v: string) =>
+    updateSearch({ cat: v === "all" ? undefined : v })
+  const setReverseCategoryFilter = (v: string) =>
+    updateSearch({ rcat: v === "all" ? undefined : v })
 
   const { data: weapons = [] } = useQuery({
     queryKey: ["weapons"],
@@ -437,13 +472,15 @@ export function CalculatorPage() {
           </Select>
           <button
             type="button"
-            onClick={() => {
-              setItemA(null)
-              setItemB(null)
-              setMaterialA(null)
-              setMaterialB(null)
-              setCategoryFilter("all")
-            }}
+            onClick={() =>
+              updateSearch({
+                s1: undefined,
+                s2: undefined,
+                m1: undefined,
+                m2: undefined,
+                cat: undefined,
+              })
+            }
             className="text-muted-foreground hover:text-foreground flex items-center gap-1 text-xs transition-colors"
           >
             <RotateCcw className="size-3" />
@@ -639,11 +676,13 @@ export function CalculatorPage() {
           </div>
           <button
             type="button"
-            onClick={() => {
-              setTargetItem(null)
-              setTargetMaterial(null)
-              setReverseCategoryFilter("all")
-            }}
+            onClick={() =>
+              updateSearch({
+                target: undefined,
+                tmat: undefined,
+                rcat: undefined,
+              })
+            }
             className="text-muted-foreground hover:text-foreground flex shrink-0 items-center gap-1 text-xs transition-colors"
           >
             <RotateCcw className="size-3" />
@@ -659,11 +698,13 @@ export function CalculatorPage() {
             itemTypeMap={itemTypeMap}
             itemStatsMap={itemStatsMap}
             onLoadRecipe={(input1, input2, mat1, mat2) => {
-              setItemA(input1)
-              setItemB(input2)
-              setMaterialA(mat1)
-              setMaterialB(mat2)
-              setCategoryFilter("all")
+              updateSearch({
+                s1: input1 || undefined,
+                s2: input2 || undefined,
+                m1: mat1 || undefined,
+                m2: mat2 || undefined,
+                cat: undefined,
+              })
               window.scrollTo({ top: 0, behavior: "smooth" })
             }}
           />

--- a/src/pages/materials/materials-page.tsx
+++ b/src/pages/materials/materials-page.tsx
@@ -1,4 +1,5 @@
-import { useMemo, useState } from "react"
+import { useCallback, useMemo } from "react"
+import { getRouteApi } from "@tanstack/react-router"
 import { useQuery } from "@tanstack/react-query"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import {
@@ -121,10 +122,33 @@ function buildLookup(recipes: MaterialRecipe[]): Lookup {
   return out
 }
 
+const routeApi = getRouteApi("/materials")
+
 export function MaterialsPage() {
-  const [category, setCategory] = useState<Category>("Blades")
-  const [type1, setType1] = useState("Heavy Mace")
-  const [type2, setType2] = useState("Heavy Mace")
+  const search = routeApi.useSearch()
+  const navigate = routeApi.useNavigate()
+
+  const updateSearch = useCallback(
+    (updates: Record<string, string | undefined>) =>
+      navigate({
+        search: (prev: Record<string, string | undefined>) => {
+          const next = { ...prev, ...updates }
+          for (const key of Object.keys(next)) {
+            if (!next[key]) delete next[key]
+          }
+          return next
+        },
+        replace: true,
+      }),
+    [navigate]
+  )
+
+  const category: Category = (
+    CATEGORIES.includes(search.cat as Category) ? search.cat : "Blades"
+  ) as Category
+  const types = getTypes(category)
+  const type1 = search.t1 && types.includes(search.t1) ? search.t1 : types[0]
+  const type2 = search.t2 && types.includes(search.t2) ? search.t2 : types[0]
 
   const { data: recipes = [], isLoading } = useQuery({
     queryKey: ["material-recipes"],
@@ -134,18 +158,20 @@ export function MaterialsPage() {
   const lookup = useMemo(() => buildLookup(recipes), [recipes])
 
   const materials = getMaterials(category)
-  const types = getTypes(category)
 
   const changeCategory = (cat: Category) => {
-    setCategory(cat)
-    const t = getTypes(cat)
-    setType1(t[0])
-    setType2(t[0])
+    updateSearch({
+      cat: cat === "Blades" ? undefined : cat,
+      t1: undefined,
+      t2: undefined,
+    })
   }
 
   const swap = () => {
-    setType1(type2)
-    setType2(type1)
+    updateSearch({
+      t1: type2 === types[0] ? undefined : type2,
+      t2: type1 === types[0] ? undefined : type1,
+    })
   }
 
   const grid = lookup[type1]?.[type2]
@@ -189,7 +215,12 @@ export function MaterialsPage() {
                 <span className="text-muted-foreground mb-1 block text-xs font-medium">
                   Slot 1
                 </span>
-                <Select value={type1} onValueChange={setType1}>
+                <Select
+                  value={type1}
+                  onValueChange={(v) =>
+                    updateSearch({ t1: v === types[0] ? undefined : v })
+                  }
+                >
                   <SelectTrigger className="w-48">
                     <SelectValue />
                   </SelectTrigger>
@@ -213,7 +244,12 @@ export function MaterialsPage() {
                 <span className="text-muted-foreground mb-1 block text-xs font-medium">
                   Slot 2
                 </span>
-                <Select value={type2} onValueChange={setType2}>
+                <Select
+                  value={type2}
+                  onValueChange={(v) =>
+                    updateSearch({ t2: v === types[0] ? undefined : v })
+                  }
+                >
                   <SelectTrigger className="w-48">
                     <SelectValue />
                   </SelectTrigger>

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -10,11 +10,17 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as MaterialsRouteImport } from './routes/materials'
+import { Route as SplatRouteImport } from './routes/$'
 import { Route as IndexRouteImport } from './routes/index'
 
 const MaterialsRoute = MaterialsRouteImport.update({
   id: '/materials',
   path: '/materials',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const SplatRoute = SplatRouteImport.update({
+  id: '/$',
+  path: '/$',
   getParentRoute: () => rootRouteImport,
 } as any)
 const IndexRoute = IndexRouteImport.update({
@@ -25,27 +31,31 @@ const IndexRoute = IndexRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/$': typeof SplatRoute
   '/materials': typeof MaterialsRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/$': typeof SplatRoute
   '/materials': typeof MaterialsRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/$': typeof SplatRoute
   '/materials': typeof MaterialsRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/materials'
+  fullPaths: '/' | '/$' | '/materials'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/materials'
-  id: '__root__' | '/' | '/materials'
+  to: '/' | '/$' | '/materials'
+  id: '__root__' | '/' | '/$' | '/materials'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  SplatRoute: typeof SplatRoute
   MaterialsRoute: typeof MaterialsRoute
 }
 
@@ -56,6 +66,13 @@ declare module '@tanstack/react-router' {
       path: '/materials'
       fullPath: '/materials'
       preLoaderRoute: typeof MaterialsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/$': {
+      id: '/$'
+      path: '/$'
+      fullPath: '/$'
+      preLoaderRoute: typeof SplatRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/': {
@@ -70,6 +87,7 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  SplatRoute: SplatRoute,
   MaterialsRoute: MaterialsRoute,
 }
 export const routeTree = rootRouteImport

--- a/src/routes/$.tsx
+++ b/src/routes/$.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from "@tanstack/react-router"
+import { NotFound } from "@/components/not-found"
+
+export const Route = createFileRoute("/$")({
+  component: NotFound,
+})

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -7,7 +7,6 @@ import {
 } from "@tanstack/react-router"
 import { Toaster } from "sonner"
 import { RootErrorComponent } from "@/components/error-boundary"
-import { NotFound } from "@/components/not-found"
 import { ThemeToggle } from "@/components/theme-toggle"
 
 const TanStackRouterDevtools = import.meta.env.PROD
@@ -24,7 +23,6 @@ interface RouterContext {
 
 export const Route = createRootRouteWithContext<RouterContext>()({
   component: RootComponent,
-  notFoundComponent: NotFound,
   errorComponent: RootErrorComponent,
 })
 

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,6 +1,29 @@
 import { createFileRoute } from "@tanstack/react-router"
+import { RootErrorComponent } from "@/components/error-boundary"
 import { CalculatorPage } from "@/pages/calculator/calculator-page"
+
+export type CalculatorSearch = {
+  s1?: string
+  s2?: string
+  m1?: string
+  m2?: string
+  target?: string
+  tmat?: string
+  cat?: string
+  rcat?: string
+}
 
 export const Route = createFileRoute("/")({
   component: CalculatorPage,
+  errorComponent: RootErrorComponent,
+  validateSearch: (search: Record<string, unknown>): CalculatorSearch => ({
+    s1: typeof search.s1 === "string" ? search.s1 : undefined,
+    s2: typeof search.s2 === "string" ? search.s2 : undefined,
+    m1: typeof search.m1 === "string" ? search.m1 : undefined,
+    m2: typeof search.m2 === "string" ? search.m2 : undefined,
+    target: typeof search.target === "string" ? search.target : undefined,
+    tmat: typeof search.tmat === "string" ? search.tmat : undefined,
+    cat: typeof search.cat === "string" ? search.cat : undefined,
+    rcat: typeof search.rcat === "string" ? search.rcat : undefined,
+  }),
 })

--- a/src/routes/materials.tsx
+++ b/src/routes/materials.tsx
@@ -1,6 +1,19 @@
 import { createFileRoute } from "@tanstack/react-router"
+import { RootErrorComponent } from "@/components/error-boundary"
 import { MaterialsPage } from "@/pages/materials/materials-page"
+
+export type MaterialsSearch = {
+  cat?: string
+  t1?: string
+  t2?: string
+}
 
 export const Route = createFileRoute("/materials")({
   component: MaterialsPage,
+  errorComponent: RootErrorComponent,
+  validateSearch: (search: Record<string, unknown>): MaterialsSearch => ({
+    cat: typeof search.cat === "string" ? search.cat : undefined,
+    t1: typeof search.t1 === "string" ? search.t1 : undefined,
+    t2: typeof search.t2 === "string" ? search.t2 : undefined,
+  }),
 })


### PR DESCRIPTION
## Summary
- Sync calculator and materials page state to URL search params for link sharing
- Fix error and 404 pages to render inside the page shell (nav/footer)

**Calculator params:** `s1`, `s2`, `m1`, `m2` (forward), `target`, `tmat` (reverse), `cat`, `rcat` (filters)
**Materials params:** `cat`, `t1`, `t2`

**Error/404 fix:** Moved notFoundComponent to catch-all route, added errorComponent to child routes, changed `min-h-svh` → `flex-1`

## Test plan
- [ ] Select items/materials on calculator → URL updates with params
- [ ] Copy URL with params, paste in new tab → state restores correctly
- [ ] Reset buttons clear all params from URL
- [ ] Click reverse lookup row → forward calc params update in URL
- [ ] Materials page category/type changes reflected in URL
- [ ] Navigate to `/asdf` → 404 page shows inside shell (nav + footer visible)
- [ ] Trigger error → error page shows inside shell

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)