### PR TITLE
Swap buttons, 1H/2H badges, materials grid improvements

### DIFF
--- a/src/pages/calculator/calculator-page.tsx
+++ b/src/pages/calculator/calculator-page.tsx
@@ -19,6 +19,7 @@ import {
   RotateCcw,
   X,
 } from "lucide-react"
+import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { ItemPicker, type PickerItem } from "@/components/item-picker"
@@ -44,8 +45,27 @@ const TYPE_LABELS: Record<string, string> = {
   AxeMace: "Axe / Mace",
 }
 
+const WEAPON_HANDS: Record<string, string> = {
+  Dagger: "1H",
+  Sword: "1H",
+  Axe: "1H",
+  Mace: "1H",
+  "Great Sword": "2H",
+  "Great Axe": "2H",
+  "Heavy Mace": "2H",
+  Polearm: "2H",
+  Staff: "2H",
+  Crossbow: "2H",
+}
+
 function typeLabel(type: string) {
   return TYPE_LABELS[type] ?? type
+}
+
+function typeLabelWithHands(type: string) {
+  const label = TYPE_LABELS[type] ?? type
+  const hands = WEAPON_HANDS[type]
+  return hands ? `${label} · ${hands}` : label
 }
 
 const ALL_MATERIALS = [
@@ -118,7 +138,13 @@ export function CalculatorPage() {
   const setTargetMaterial = (v: string | null) =>
     updateSearch({ tmat: v || undefined })
   const setCategoryFilter = (v: string) =>
-    updateSearch({ cat: v === "all" ? undefined : v })
+    updateSearch({
+      cat: v === "all" ? undefined : v,
+      s1: undefined,
+      s2: undefined,
+      m1: undefined,
+      m2: undefined,
+    })
   const setReverseCategoryFilter = (v: string) =>
     updateSearch({ rcat: v === "all" ? undefined : v })
 
@@ -248,6 +274,16 @@ export function CalculatorPage() {
     }
     return map
   }, [allItems, recipes])
+
+  // Map item name → 1H/2H for weapon badges
+  const itemHandsMap = useMemo(() => {
+    const map = new Map<string, string>()
+    for (const w of weapons) {
+      const hands = WEAPON_HANDS[w.blade_type]
+      if (hands) map.set(fmt(w.field_name), hands)
+    }
+    return map
+  }, [weapons])
 
   // Map item name → equipment category for material filtering
   const equipCategoryMap = useMemo(() => {
@@ -509,8 +545,24 @@ export function CalculatorPage() {
             materialData={materialA ? materialMap.get(materialA) : undefined}
           />
 
-          <div className="flex shrink-0 items-center">
-            <Plus className="text-muted-foreground size-10" />
+          <div className="flex shrink-0 flex-col items-center justify-center gap-1">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() =>
+                updateSearch({
+                  s1: itemB || undefined,
+                  s2: itemA || undefined,
+                  m1: materialB || undefined,
+                  m2: materialA || undefined,
+                })
+              }
+              className="text-lg"
+              title="Swap slots"
+            >
+              ⇄
+            </Button>
+            <Plus className="text-muted-foreground size-6" />
           </div>
 
           <ItemCard
@@ -568,7 +620,7 @@ export function CalculatorPage() {
                         </span>
                         {resultType && (
                           <span className="text-muted-foreground shrink-0 text-xs">
-                            {typeLabel(resultType)}
+                            {typeLabelWithHands(resultType)}
                           </span>
                         )}
                       </div>
@@ -664,7 +716,7 @@ export function CalculatorPage() {
                   setTargetMaterial(null)
               }}
               placeholder="Search for a result item..."
-              formatType={typeLabel}
+              formatType={typeLabelWithHands}
             />
           </div>
           <div className="sm:w-48">
@@ -697,6 +749,7 @@ export function CalculatorPage() {
             targetItem={targetItem}
             itemTypeMap={itemTypeMap}
             itemStatsMap={itemStatsMap}
+            itemHandsMap={itemHandsMap}
             onLoadRecipe={(input1, input2, mat1, mat2) => {
               updateSearch({
                 s1: input1 || undefined,
@@ -750,7 +803,7 @@ function ItemCard({
           value={value}
           onSelect={onSelect}
           placeholder={`Choose ${title.toLowerCase()}...`}
-          formatType={typeLabel}
+          formatType={typeLabelWithHands}
         />
         <MaterialSelect
           materials={availableMaterials}
@@ -786,6 +839,7 @@ function ReverseTable({
   targetItem,
   itemTypeMap,
   itemStatsMap,
+  itemHandsMap,
   onLoadRecipe,
 }: {
   rows: ReverseRow[]
@@ -793,6 +847,7 @@ function ReverseTable({
   targetItem: string | null
   itemTypeMap: Map<string, string>
   itemStatsMap: Map<string, ItemStats>
+  itemHandsMap: Map<string, string>
   onLoadRecipe: (
     input1: string,
     input2: string,
@@ -813,6 +868,7 @@ function ReverseTable({
           <SlotCell
             name={row.original.input_1}
             type={itemTypeMap.get(row.original.input_1)}
+            hands={itemHandsMap.get(row.original.input_1)}
             stats={itemStatsMap.get(row.original.input_1)}
             compareWith={resultStats}
             materials={
@@ -835,6 +891,7 @@ function ReverseTable({
           <SlotCell
             name={row.original.input_2}
             type={itemTypeMap.get(row.original.input_2)}
+            hands={itemHandsMap.get(row.original.input_2)}
             stats={itemStatsMap.get(row.original.input_2)}
             compareWith={resultStats}
             materials={
@@ -851,7 +908,7 @@ function ReverseTable({
         ),
       },
     ],
-    [targetMaterial, itemTypeMap, itemStatsMap, resultStats]
+    [targetMaterial, itemTypeMap, itemStatsMap, itemHandsMap, resultStats]
   )
 
   const table = useReactTable({
@@ -888,6 +945,7 @@ function ReverseTable({
             <SlotCell
               name={targetItem}
               type={itemTypeMap.get(targetItem)}
+              hands={itemHandsMap.get(targetItem)}
               stats={itemStatsMap.get(targetItem)}
             />
           </div>
@@ -1007,12 +1065,14 @@ const MAT_BADGE_COLORS: Record<string, string> = {
 function SlotCell({
   name,
   type,
+  hands,
   stats,
   compareWith,
   materials,
 }: {
   name: string
   type?: string
+  hands?: string
   stats?: ItemStats
   compareWith?: ItemStats
   materials?: string[]
@@ -1025,6 +1085,7 @@ function SlotCell({
         {type && (
           <span className="text-muted-foreground text-xs">
             {typeLabel(type)}
+            {hands && ` · ${hands}`}
           </span>
         )}
       </div>

--- a/src/pages/materials/materials-page.tsx
+++ b/src/pages/materials/materials-page.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useMemo } from "react"
 import { getRouteApi } from "@tanstack/react-router"
 import { useQuery } from "@tanstack/react-query"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent } from "@/components/ui/card"
 import {
   Select,
   SelectContent,
@@ -207,78 +208,69 @@ export function MaterialsPage() {
           ))}
         </div>
 
-        {/* Type pair selector */}
-        {category !== "Shields" && (
-          <Card>
-            <CardContent className="flex items-end justify-center gap-3 pt-6">
-              <div className="w-48">
-                <span className="text-muted-foreground mb-1 block text-xs font-medium">
-                  Slot 1
-                </span>
-                <Select
-                  value={type1}
-                  onValueChange={(v) =>
-                    updateSearch({ t1: v === types[0] ? undefined : v })
-                  }
-                >
-                  <SelectTrigger className="w-48">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {types.map((t) => (
-                      <SelectItem key={t} value={t}>
-                        {label(t)}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-              <button
-                onClick={swap}
-                className="text-muted-foreground hover:text-foreground flex h-9 shrink-0 items-center px-1 text-lg transition-colors"
-                title="Swap slots"
-              >
-                ⇄
-              </button>
-              <div className="w-48">
-                <span className="text-muted-foreground mb-1 block text-xs font-medium">
-                  Slot 2
-                </span>
-                <Select
-                  value={type2}
-                  onValueChange={(v) =>
-                    updateSearch({ t2: v === types[0] ? undefined : v })
-                  }
-                >
-                  <SelectTrigger className="w-48">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {types.map((t) => (
-                      <SelectItem key={t} value={t}>
-                        {label(t)}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-            </CardContent>
-          </Card>
-        )}
-
         {/* Material Grid */}
         <Card>
-          <CardHeader className="pb-3">
-            <CardTitle className="text-base">
-              {category === "Shields"
-                ? "Shield Materials"
-                : `${label(type1)} + ${label(type2)}`}
-            </CardTitle>
-            <p className="text-muted-foreground text-xs">
+          <CardContent className="space-y-4 pt-6">
+            {category !== "Shields" && (
+              <div className="flex items-end justify-center gap-3">
+                <div className="w-48">
+                  <span className="text-muted-foreground mb-1 block text-xs font-medium">
+                    Slot 1
+                  </span>
+                  <Select
+                    value={type1}
+                    onValueChange={(v) =>
+                      updateSearch({ t1: v === types[0] ? undefined : v })
+                    }
+                  >
+                    <SelectTrigger className="w-48">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {types.map((t) => (
+                        <SelectItem key={t} value={t}>
+                          {label(t)}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={swap}
+                  className="shrink-0 text-lg"
+                  title="Swap slots"
+                >
+                  ⇄
+                </Button>
+                <div className="w-48">
+                  <span className="text-muted-foreground mb-1 block text-xs font-medium">
+                    Slot 2
+                  </span>
+                  <Select
+                    value={type2}
+                    onValueChange={(v) =>
+                      updateSearch({ t2: v === types[0] ? undefined : v })
+                    }
+                  >
+                    <SelectTrigger className="w-48">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {types.map((t) => (
+                        <SelectItem key={t} value={t}>
+                          {label(t)}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+            )}
+            <p className="text-muted-foreground text-center text-xs">
               Cell = result material from combining Slot 1 and Slot 2
             </p>
-          </CardHeader>
-          <CardContent>
             {isLoading ? (
               <p className="text-muted-foreground py-8 text-center text-sm">
                 Loading...
@@ -288,6 +280,8 @@ export function MaterialsPage() {
                 grid={grid}
                 reverseGrid={reverseGrid}
                 materials={materials}
+                type1Label={label(type1)}
+                type2Label={label(type2)}
               />
             ) : (
               <p className="text-muted-foreground py-8 text-center text-sm">
@@ -351,10 +345,14 @@ function MaterialGrid({
   grid,
   reverseGrid,
   materials,
+  type1Label,
+  type2Label,
 }: {
   grid: Record<string, Record<string, Cell>>
   reverseGrid?: Record<string, Record<string, Cell>>
   materials: string[]
+  type1Label?: string
+  type2Label?: string
 }) {
   return (
     <div className="flex justify-center overflow-x-auto">
@@ -364,9 +362,14 @@ function MaterialGrid({
             <th colSpan={2} />
             <th
               colSpan={materials.length}
-              className="text-muted-foreground pb-1 text-[10px] font-normal"
+              className="text-muted-foreground pb-1 font-normal"
             >
-              Slot 2
+              <div className="text-xs">Slot 2</div>
+              {type2Label && (
+                <div className="text-xs font-medium opacity-60">
+                  {type2Label}
+                </div>
+              )}
             </th>
           </tr>
           <tr>
@@ -391,9 +394,14 @@ function MaterialGrid({
               {i === 0 && (
                 <td
                   rowSpan={materials.length}
-                  className="text-muted-foreground pr-2 align-middle text-[10px] font-normal"
+                  className="text-muted-foreground pr-2 align-middle font-normal"
                 >
-                  Slot 1
+                  <div className="text-xs">Slot 1</div>
+                  {type1Label && (
+                    <div className="text-xs font-medium opacity-60">
+                      {type1Label}
+                    </div>
+                  )}
                 </td>
               )}
               <td className="p-1.5">
@@ -440,7 +448,7 @@ function MaterialGrid({
                             ? "ring-red-400"
                             : "ring-transparent"
                       )}
-                      title={`Slot 1: ${mat1} + Slot 2: ${mat2} → ${result}${upgrade ? " (upgrade)" : ""}${downgrade ? " (downgrade)" : ""}${nonComm ? " (swap gives " + rev!.result + ")" : ""}`}
+                      title={`Slot 1: ${mat1} + Slot 2: ${mat2} → ${result}${upgrade ? " (upgrade)" : ""}${downgrade ? " (downgrade)" : ""}${nonComm ? ` (swapping slots gives ${rev!.result} instead)` : ""}`}
                     >
                       {MAT_SHORT[result]}
                       {nonComm && (


### PR DESCRIPTION
## Summary
- Add swap button to forward calculator (swaps items + materials)
- Outline button style for swap in both pages
- 1H/2H weapon handedness badges on type labels
- Category filter change resets items in forward calculator
- Materials grid: merged selectors into grid card, removed separate header
- Larger Slot 1/2 and type labels in material grid

## Test plan
- [ ] Forward calculator swap button swaps both items and materials
- [ ] Weapon items show 1H/2H badge (e.g. "Dagger · 1H", "Great Sword · 2H")
- [ ] Armor/shields show no handedness badge
- [ ] Changing category filter clears selected items
- [ ] Materials page type selectors are inside the grid card
- [ ] Slot 1/2 and type labels are readable in the grid

🤖 Generated with [Claude Code](https://claude.com/claude-code)